### PR TITLE
Add repo_checker python script for auto checks

### DIFF
--- a/python/repo_checker/repo_checker.py
+++ b/python/repo_checker/repo_checker.py
@@ -71,12 +71,16 @@ def find_repos(start_path: str) -> list[str]:
 
 
 def get_committed_files(repo_path: str) -> list[str]:
-    output = run_cmd("git ls-files", repo_path)
-    if not output:
-        return []
-    if output.startswith("ERROR:"):
+    try:
+        output = run_cmd("git ls-files", repo_path)
+    except Exception as e:
         # Failed to list committed files; log and return an empty list.
-        print(output, file=sys.stderr)
+        print(
+            f"⚠️ Failed to list committed files in {repo_path!r}: {e}",
+            file=sys.stderr,
+        )
+        return []
+    if not output:
         return []
     return output.splitlines()
 


### PR DESCRIPTION
## Description

Add repo_checker python script for auto checks. It can dynamically find the git repos in the root folder or through the specified folder via the python arguments.

Usage:
`python auto_checker.py`

`python auto_checker.py [path/to/folder]`

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #61 

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

<!-- Steps or notes on how reviewers can verify. -->
