### PR TITLE
Add java maven project structure template

### DIFF
--- a/templates/project_structures/java/.gitignore
+++ b/templates/project_structures/java/.gitignore
@@ -1,0 +1,39 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+.kotlin
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/templates/project_structures/java/README.md
+++ b/templates/project_structures/java/README.md
@@ -1,0 +1,44 @@
+# Java Template
+
+Uses Maven & Java JDK 25 LTS
+
+## Structure
+
+- root files (README.md, pom.xml, .gitignore, etc.)
+- src
+  - main
+    - java
+    - resources
+  - test
+    - tests
+
+## Setup
+
+### Install & Build
+
+```bash
+mvn clean install
+```
+
+### Test
+
+```bash
+mvn test
+```
+
+### Run
+
+```bash
+cd target
+```
+
+```bash
+java -jar templateRaw.jar
+```
+
+## Notes
+
+- Make sure to have Java JDK 25 LTS installed and configured in your environment.
+- Maven is used for dependency management and build automation.
+- Adjust the `pom.xml` file to add any additional dependencies as needed.
+- You can customize the project structure further based on your requirements.

--- a/templates/project_structures/java/pom.xml
+++ b/templates/project_structures/java/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.felixnagele</groupId>
+    <artifactId>template</artifactId>
+    <version>1.0</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>25</java.version>
+        <!-- My Main Class -->
+        <project.mainClass>io.github.felixnagele.main.Main</project.mainClass>
+
+        <!-- BUILD PLUGIN VERSIONS -->
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
+        <maven.compiler.version>3.14.0</maven.compiler.version>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin -->
+        <maven.jar.version>3.5.0</maven.jar.version>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
+        <maven.dependency.version>3.9.0</maven.dependency.version>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
+        <maven.assembly.version>3.8.0</maven.assembly.version>
+    </properties>
+
+    <build>
+        <finalName>${project.artifactId}Raw</finalName>
+        <plugins>
+            <!-- Plugin to compile Java source files -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <configuration>
+                    <source>${java.version}</source> <!-- Specify your source compatibility Java version -->
+                    <target>${java.version}</target> <!-- Specify your target compatibility Java version -->
+                </configuration>
+            </plugin>
+
+            <!-- Plugin to create a JAR with only your application code -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${project.mainClass}</mainClass> <!-- Application entry point -->
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <!-- Plugin to copy dependencies to a separate directory -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.version}</version>
+                <executions>
+                    <execution>
+                        <id>unpack-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+            Plugin to create distributions (assemblies) of your Maven project.
+            It allows you to bundle your project along with its dependencies,
+            configuration files, documentation, and other resources into
+            a single compressed file format, such as a ZIP, TAR.GZ, or JAR file.
+            This is particularly useful for packaging applications that need
+            to be distributed to end-users or deployed to servers.
+
+            By setting addClasspath to true and defining the mainClass,
+            the classpath gets added to the manifest file of the assembled JAR.
+            This is necessary for an executable JAR.
+            -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.version}</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>${project.mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Java Testing -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>6.1.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/templates/project_structures/java/src/main/java/io/github/felixnagele/main/Main.java
+++ b/templates/project_structures/java/src/main/java/io/github/felixnagele/main/Main.java
@@ -1,0 +1,11 @@
+package io.github.felixnagele.main;
+
+public class Main {
+    static void main() {
+        IO.println("Hello and welcome!");
+
+        for (int i = 1; i <= 5; i++) {
+            IO.println("i = " + i);
+        }
+    }
+}

--- a/templates/project_structures/java/src/main/resources/META-INF/MANIFEST.MF
+++ b/templates/project_structures/java/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Main-Class: io.github.felixnagele.main.Main

--- a/templates/project_structures/java/src/main/resources/data.env
+++ b/templates/project_structures/java/src/main/resources/data.env
@@ -1,0 +1,2 @@
+USER=name
+PASSWORD=admin

--- a/templates/project_structures/java/src/test/java/io/github/felixnagele/MainTest.java
+++ b/templates/project_structures/java/src/test/java/io/github/felixnagele/MainTest.java
@@ -1,0 +1,17 @@
+package io.github.felixnagele;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Simple “smoke” test to verify that the test setup is working.
+ */
+public class MainTest {
+
+    @Test
+    void sanityCheckAlwaysPasses() {
+        // this test always passes, ensuring your test suite is wired up correctly
+        assertTrue(true, "This test should always pass");
+    }
+}


### PR DESCRIPTION
## Description

Add java maven project structure template. Maven, java jdk25 and other important maven plugins are used. The readme file explains the structure and setup.

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #69 

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

```bash
mvn clean install
```

```bash
mvn test
```
