### PR TITLE
Fix CD temporary directory for the release bundle issue

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,8 @@ jobs:
         run: |
           VERSION="${{ github.event.workflow_run.head_sha || github.sha }}"
           VERSION="${VERSION:0:12}"
-          BUNDLE="playground-${VERSION}.tar.gz"
+          BUNDLE_DIR="$(mktemp -d)"
+          BUNDLE="$BUNDLE_DIR/playground-${VERSION}.tar.gz"
 
           tar \
             --exclude='.git' \


### PR DESCRIPTION
## Description

Fixes the following CD issue:
```
tar: .: file changed as we read it
Error: Process completed with exit code 1.
```

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #<issue-number>

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

Manual CD run
